### PR TITLE
Update Kotlin samples to use 18.32.0 version

### DIFF
--- a/ConvertToOffice/pom.xml
+++ b/ConvertToOffice/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/FlattenTransparency/pom.xml
+++ b/FlattenTransparency/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/ListWords/pom.xml
+++ b/ListWords/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/MergePDF/pom.xml
+++ b/MergePDF/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/PDFAConverter/pom.xml
+++ b/PDFAConverter/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/PDFOptimize/pom.xml
+++ b/PDFOptimize/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/RasterizePage/pom.xml
+++ b/RasterizePage/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/Redactions/pom.xml
+++ b/Redactions/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/RegexExtractText/pom.xml
+++ b/RegexExtractText/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
         <dependency>

--- a/RegexTextSearch/pom.xml
+++ b/RegexTextSearch/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/SplitPDF/pom.xml
+++ b/SplitPDF/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/TextExtract/pom.xml
+++ b/TextExtract/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>

--- a/Watermark/pom.xml
+++ b/Watermark/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>18.31.0</version>
+            <version>18.32.0</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Let's update the version of the Java Maven package that the Kotlin samples are using.