### PR TITLE
Fix CWE-78 command-injection semgrep issue

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -61,9 +61,14 @@ def remove_last_path_entry():
 
 
 def execute_kotlin_sample(target_dir, sample_name, full_path, apdfl_key):
-    command = str(f'java -Djava.library.path={target_dir} -jar target/{sample_name}-1.0-SNAPSHOT-jar-with-dependencies.jar')
+    command = [
+        'java',
+        f'-Djava.library.path={target_dir}',
+        '-jar',
+        f'target/{sample_name}-1.0-SNAPSHOT-jar-with-dependencies.jar'
+    ]
 
-    process = subprocess.Popen(command, shell=True, cwd=full_path,
+    process = subprocess.Popen(command, shell=False, cwd=full_path,
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     process.stdin.write(apdfl_key.encode() + b'\n')


### PR DESCRIPTION
- Corrects a semgrep issue where command can be injected via shell: https://semgrep.dev/orgs/datalogics/findings/212820383

Fulfills **JIRA issue**: [APDFL-6316](https://datalogics-jira.atlassian.net/browse/APDFL-6316)

[APDFL-6316]: https://datalogics-jira.atlassian.net/browse/APDFL-6316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ