### PR TITLE
Pin APDFL dependency to 18.x version range

### DIFF
--- a/AddBasicPAdESElectronicSignature/pom.xml
+++ b/AddBasicPAdESElectronicSignature/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/AddDigitalSignatureCMS/pom.xml
+++ b/AddDigitalSignatureCMS/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/AddDigitalSignatureRFC3161/pom.xml
+++ b/AddDigitalSignatureRFC3161/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/AddPAdESPolicySignature/pom.xml
+++ b/AddPAdESPolicySignature/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/ConvertToOffice/pom.xml
+++ b/ConvertToOffice/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/FlattenTransparency/pom.xml
+++ b/FlattenTransparency/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/ListWords/pom.xml
+++ b/ListWords/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/MergePDF/pom.xml
+++ b/MergePDF/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/PDFAConverter/pom.xml
+++ b/PDFAConverter/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/PDFOptimize/pom.xml
+++ b/PDFOptimize/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/RasterizePage/pom.xml
+++ b/RasterizePage/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/Redactions/pom.xml
+++ b/Redactions/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/RegexExtractText/pom.xml
+++ b/RegexExtractText/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
         <dependency>
@@ -147,36 +147,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/RegexTextSearch/pom.xml
+++ b/RegexTextSearch/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/SplitPDF/pom.xml
+++ b/SplitPDF/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/TextExtract/pom.xml
+++ b/TextExtract/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/Watermark/pom.xml
+++ b/Watermark/pom.xml
@@ -71,32 +71,32 @@
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <type>zip</type>
             <classifier>resources</classifier>
         </dependency>
         <dependency>
             <groupId>com.datalogics.pdfl</groupId>
             <artifactId>pdfl</artifactId>
-            <version>LATEST</version>
+            <version>[18.0.0,19.0.0)</version>
             <classifier>javadoc</classifier>
         </dependency>
     </dependencies>
@@ -142,36 +142,28 @@
                         <id>unpack-resources</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>resources</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>resources</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib/Resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
                         <id>unpack-jni</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.datalogics.pdfl</groupId>
-                                    <artifactId>pdfl</artifactId>
-                                    <classifier>${jni.classifier}</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
+                            <includeGroupIds>com.datalogics.pdfl</includeGroupIds>
+                            <includeArtifactIds>pdfl</includeArtifactIds>
+                            <includeClassifiers>${jni.classifier}</includeClassifiers>
+                            <includeTypes>zip</includeTypes>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- Replace `LATEST` with the `[18.0.0,19.0.0)` version range on all `com.datalogics.pdfl:pdfl` dependencies, so the samples resolve the latest **18.x** release instead of `21.0.0` (the current overall `LATEST`).
- Switch both `maven-dependency-plugin` unpack executions from `unpack` to `unpack-dependencies` with include filters.

## Why
The `maven-dependency-plugin` `unpack` goal resolves its versionless `<artifactItem>` entries to a literal version string and does **not** evaluate Maven version ranges — so with a range it failed to find the native/resources artifacts (`pdfl:zip:resources:[18.0.0,19.0.0)` "not found"). `unpack-dependencies` resolves against the `<dependencies>` section, where the range is honored.

Applied across all 17 sample poms, matching the fix already landed in `apdfl-java-maven-samples` `develop-18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)