### PR TITLE
APDFL-6734: Fix Windows ARM CI for APDFL 21 Kotlin samples

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,14 +87,16 @@ pipeline {
                                         returnStdout: true
                                     ).trim()
                                 } else {
-                                    // Using the mkenv.py script like this assumes the Python Launcher is
-                                    // installed on the Windows host.
-                                    // https://docs.python.org/3/using/windows.html#launcher
-                                    bat '.\\mkenv.py --verbose'
+                                    // Invoke through the Python Launcher (py) explicitly rather than
+                                    // relying on the .py file association, which on some Windows hosts
+                                    // (e.g. the Windows ARM node) does not forward arguments (%*).
+                                    // Without the argument, mkenv.py runs a full environment setup and
+                                    // prints pip output, corrupting the venv path captured below.
+                                    bat 'py mkenv.py --verbose'
                                     ENV_LOC[NODE] = bat (
                                         // The @ prevents Windows from echoing the command itself into the stdout,
                                         // which would corrupt the value of the returned data.
-                                        script: '@.\\mkenv.py --env-name',
+                                        script: '@py mkenv.py --env-name',
                                         returnStdout: true
                                     ).trim()
                                 }

--- a/tasks.py
+++ b/tasks.py
@@ -106,8 +106,13 @@ def run_samples(ctx):
         if platform.system() == 'Windows':
             os.environ["PATH"] += str(target_dir)
 
-        if platform.system() in ('Darwin', 'Linux') and 'ConvertToOffice' in sample:
-            print(f'{sample} not available on this OS')
+        # Office conversion isn't available on macOS, Linux, or Windows ARM64 --
+        # PDFToOffice is only built for Windows x64 and Linux x64, so on the
+        # others ConvertToOffice throws "not implemented on this platform" at runtime.
+        is_windows_arm = (platform.system() == 'Windows'
+                          and platform.machine().upper() in ('ARM64', 'AARCH64'))
+        if (platform.system() in ('Darwin', 'Linux') or is_windows_arm) and 'ConvertToOffice' in sample:
+            print(f'{sample} not available on this platform')
             continue
 
         sample_name = sample.split("/")[0]


### PR DESCRIPTION
Two Windows-ARM fixes for the Kotlin samples CI on `develop-21`.

## 1. Invoke mkenv via the `py` launcher on Windows
On the Windows ARM node the `.py` file association doesn't forward arguments, so `@.\mkenv.py --env-name` ran without the argument — mkenv did a full setup and printed pip output, corrupting the captured venv path and breaking venv activation in the Clean Samples stage. Invoke `py mkenv.py` explicitly (for both `--verbose` and `--env-name`) so the argument is passed through. Windows-only; the Unix `./mkenv.py` calls are unchanged. Mirrors the existing fix on `apdfl-java-maven-samples`.

## 2. Skip ConvertToOffice on Windows ARM
PDFToOffice ships only for Windows x64 and Linux x64; on Windows ARM64 `ConvertToOffice` throws "Office conversion is not implemented on this platform" at runtime. Extend the existing macOS/Linux run-time skip to also cover Windows ARM64 (detected via `platform.machine()`). The sample still builds on Windows ARM — only the run is skipped.

## Notes
- The earlier Windows ARM `Library()` crash (`0xC0000005`) was **not** in this repo — it was a stale `msvcp140` (14.31) bundled in the node's Zulu JDK; fixed by moving that node to a Zulu bundling msvcp140 >= 14.38. With that node fix, build #6's win-arm axis ran the signature samples successfully and failed only on ConvertToOffice (addressed here).
- Verified on `develop-21` PR-75 build #6.