### PR TITLE
WIP: Remove nightly build trigger for develop-18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,6 @@ pipeline {
         timeout(time: 4, unit: "HOURS")
     }
     agent none
-    triggers {
-        // The job will be triggered only for the develop branch at midnight every day.
-        parameterizedCron(env.BRANCH_NAME == "develop-18" ? "0 8 * * *" : "")
-    }
     stages {
         stage('Matrix stage') {
             matrix {


### PR DESCRIPTION
Removes the `triggers` block so the develop-18 branch no longer builds nightly.

**Do not merge yet** — waiting for the next APDFL 21 release to be approved by QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)